### PR TITLE
overwrite the calculateNearbyPlayers methods

### DIFF
--- a/frontend/src/classes/Vehicle.ts
+++ b/frontend/src/classes/Vehicle.ts
@@ -95,6 +95,16 @@ import { ServerPlayer } from "./Player";
       }
       throw Error('No Driver on the vehicle');
     }
+
+    gainAllPassengersID() : string[] {
+      const passengersIDList : string[] = [];
+      if (this.passengers){
+        for (let i = 0; i<this.passengers?.length; i+=1){
+          passengersIDList.push(this.passengers[i]._player._id);
+        }
+      }
+      return passengersIDList;
+    }
   }
 
   // Might need to add conversatoin in the next week.


### PR DESCRIPTION
Realize the functionality of private video conversation by overwriting the calculateNearbyPlayers methods. To be notified, the original chat functionality is for all players rather than nearbyPlayers. As a result, the chat box conversation is not private.